### PR TITLE
forces jest to import the commonjs axios build

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
     "colors": "^1.4.0",
     "prettier": "3.0.3"
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^axios$": "axios/dist/node/axios.cjs"
+    }
+  },
   "engines": {
     "node": ">=16.0.0"
   },


### PR DESCRIPTION
Some candidates waste a lot of time when trying to figure out why their tests are crashing when they use axios in their components.